### PR TITLE
Update Rufus-Scheduler version

### DIFF
--- a/smashing.gemspec
+++ b/smashing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sinatra', '~> 1.4.4')
   s.add_dependency('sinatra-contrib', '~> 1.4.2')
   s.add_dependency('thin', '~> 1.6.1')
-  s.add_dependency('rufus-scheduler', '~> 2.0.24')
+  s.add_dependency('rufus-scheduler', '~> 3.2.0')
   s.add_dependency('thor', '~> 0.19')
   s.add_dependency('sprockets', '~> 2.10.1')
   s.add_dependency('rack', '~> 1.5.4')


### PR DESCRIPTION
Uses a new (rewritten) version of Rufus-Scheduler.

This is mostly backwards compatible, and it works out of the box with our Dashboards; but others may find they require some minor compat changes to existing jobs. It's probably best to check with the [rufus-scheduler README](https://raw.githubusercontent.com/jmettraux/rufus-scheduler/master/README.md) under the notable changes section if anything here is likely to affect your jobs.

I'm hoping that using a new Rufus-Scheduler won't exhibit some nasty memory leaking behaviour we observed where objects from previous jobs aren't properly dereferenced.

At the very least, this makes any future updates a bit less of a leap and a bit easier to accomodate for.
