### PR TITLE
Fix links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![Gitter chat](https://badges.gitter.im/smashing.png)](https://gitter.im/Smashing)
 
-# [Smashing](https://github.com/dashing-io/smashing/wiki)
+# [Smashing](https://github.com/Smashing/smashing/wiki)
 
 Smashing, the spiritual successor to [Dashing](https://github.com/Shopify/dashing), is a Sinatra based framework that lets you build excellent dashboards. It looks especially great on TVs.
 
 ## Community
 
-Feel free to submit issues for bugs, new features, and enhancements in [GitHub](https://github.com/SmashingDashboard/smashing/issues). For more general questions, or help with widgets, please use the [gitter chatroom](https://gitter.im/Smashing).
+Feel free to submit issues for bugs, new features, and enhancements in [GitHub](https://github.com/Smashing/smashing/issues). For more general questions, or help with widgets, please use the [gitter chatroom](https://gitter.im/Smashing).
 
 ## Installation
 
@@ -25,7 +25,7 @@ $ bundle
 $ smashing start
 ```
 
-[Check out our wiki](https://github.com/SmashingDashboard/smashing/wiki).
+[Check out our wiki](https://github.com/Smashing/smashing/wiki).
 
 Note: This is a fork of the Dashing project, which is no longer being maintained. Read about that [here](https://github.com/Shopify/dashing/issues/711).
 

--- a/smashing.gemspec
+++ b/smashing.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "The wonderfully excellent dashboard framework."
   s.description = "A framework for pulling together an overview of data that is important to your team and displaying it easily on TVs around the office. You write a bit of ruby code to gather data from some services and let Smashing handle the rest - displaying that data in a wonderfully simple layout. Built for developers and hackers, Smashing is highly customizable while maintaining humble roots that make it approachable to beginners."
   s.author      = "Daniel Beauchamp"
-  s.homepage    = 'http://smashing.github.io'
+  s.homepage    = 'http://smashing.github.io/smashing'
   s.license     = "MIT"
 
   s.files = Dir['README.md', 'javascripts/**/*', 'templates/**/*','templates/**/.[a-z]*', 'lib/**/*']

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -1,1 +1,1 @@
-Check out http://smashing.github.io/ for more information.
+Check out http://smashing.github.io/smashing for more information.


### PR DESCRIPTION
:notebook: Updates several links based on previous GitHub organisations, and fixes a couple of links to `smashing.github.io` to include `/smashing`.