### PR TITLE
Capture Interrupt error (Ctrl+c) and cleanly exit

### DIFF
--- a/lib/dashing/cli.rb
+++ b/lib/dashing/cli.rb
@@ -86,7 +86,11 @@ module Dashing
     private
 
     def run_command(command)
-      system(command)
+      begin
+        system(command)
+      rescue Interrupt => e
+        say "Exiting..."
+      end
     end
 
     def install_widget_from_gist(gist, skip_overwrite)


### PR DESCRIPTION
Another request, now from a fellow developer that was working on a dashboard created with Smashing. While fixing exceptions, he mentioned that having one less exception could help identifying errors.

He was talking about the Interrupt error that we have in logs when we stop the command with a CTRL+C.

```
$ smashing start
Thin web server (v1.6.4 codename Gob Bluth)
Maximum connections set to 1024
Listening on 0.0.0.0:3030, CTRL+C to stop
For the twitter widget to work, you need to put in your twitter API keys in the jobs/twitter.rb file.
^C/var/lib/gems/2.3.0/gems/smashing-1.0.0/lib/dashing/cli.rb:89:in `system': Interrupt
	from /var/lib/gems/2.3.0/gems/smashing-1.0.0/lib/dashing/cli.rb:89:in `run_command'
	from /var/lib/gems/2.3.0/gems/smashing-1.0.0/lib/dashing/cli.rb:64:in `start'
	from /var/lib/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /var/lib/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /var/lib/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /var/lib/gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /var/lib/gems/2.3.0/gems/smashing-1.0.0/bin/smashing:9:in `<top (required)>'
	from /usr/local/bin/smashing:23:in `load'
	from /usr/local/bin/smashing:23:in `<main>'
```

This pull request simply wraps the call to `system` capturing the Interrupt error, and printing an exit message. Based on [this commit of power](https://github.com/powder-rb/powder/commit/e36fe88c5bd3e35caac37b34a5a654f7e5585f98).

What others think of this change? With this code, the command would print.

```
$ smashing start
Thin web server (v1.6.4 codename Gob Bluth)
Maximum connections set to 1024
Listening on 0.0.0.0:3030, CTRL+C to stop
For the twitter widget to work, you need to put in your twitter API keys in the jobs/twitter.rb file.
^CExiting...
```

Cheers
Bruno