### PR TITLE
don't multiply the updatedAt timestamp by 1000

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -46,7 +46,7 @@ class Dashing.Widget extends Batman.View
 
   @accessor 'updatedAtMessage', ->
     if updatedAt = @get('updatedAt')
-      timestamp = new Date(updatedAt * 1000)
+      timestamp = new Date(updatedAt)
       hours = timestamp.getHours()
       minutes = ("0" + timestamp.getMinutes()).slice(-2)
       "Last updated at #{hours}:#{minutes}"


### PR DESCRIPTION
The updatedAt timestamp has already been multiplied by 1000 at https://github.com/Smashing/smashing/blob/master/lib/dashing/app.rb#L141
so there is no need to multiply it again.

See https://github.com/Smashing/smashing/commit/fce2ae11158aa39d1a3a5572707a997384afc6fc