### PR TITLE
Travis: Change to pre-installed Rubies, drop 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
 
 script: "rake test"


### PR DESCRIPTION
This PR 

- drops 2.1 as a CI target
- changes the CI matrix to have only preinstalled Ruby versions (faster!)