### PR TITLE
Switch from Thin to Puma (port of smashing/puma_webserver branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 *.gem
 coverage/
 log/
-tmp/
 .ruby-version
 history.yml

--- a/lib/dashing/cli.rb
+++ b/lib/dashing/cli.rb
@@ -57,16 +57,20 @@ module Dashing
     desc "start", "Starts the server in style!"
     method_option :job_path, :desc => "Specify the directory where jobs are stored"
     def start(*args)
-      port_option = args.include?('-p') ? '' : ' -p 3030'
+      daemonize = args.include?('-d')
       args = args.join(' ')
-      command = "bundle exec thin -R config.ru start#{port_option} #{args}"
+      command = "bundle exec puma #{args}"
       command.prepend "export JOB_PATH=#{options[:job_path]}; " if options[:job_path]
+      command.prepend "export DAEMONIZE=true; " if daemonize
       run_command(command)
     end
 
-    desc "stop", "Stops the thin server"
-    def stop
-      command = "bundle exec thin stop"
+    desc "stop", "Stops the puma server (daemon mode only)"
+    def stop(*args)
+      args = args.join(' ')
+      # TODO correctly handle pidfile location change in puma config
+      daemon_pidfile = !args.include?('--pidfile') ? '--pidfile ./tmp/pids/puma.pid' : args
+      command = "bundle exec pumactl #{daemon_pidfile} stop"
       run_command(command)
     end
 

--- a/smashing.gemspec
+++ b/smashing.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('execjs', '~> 2.0.2')
   s.add_dependency('sinatra', '~> 1.4.4')
   s.add_dependency('sinatra-contrib', '~> 1.4.2')
-  s.add_dependency('thin', '~> 1.6.1')
+  s.add_dependency('puma', '~> 3.11.0')
   s.add_dependency('rufus-scheduler', '~> 3.2.0')
   s.add_dependency('thor', '~> 0.19')
   s.add_dependency('sprockets', '~> 2.10.1')

--- a/templates/project/config/puma.rb
+++ b/templates/project/config/puma.rb
@@ -1,0 +1,42 @@
+# For a complete list of puma configuration parameters, please see
+# https://github.com/puma/puma
+
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum.
+#
+threads_count = ENV.fetch("PUMA_MAX_THREADS") { 5 }.to_i
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests, default is 2020.
+#
+port        ENV.fetch("DASHING_PORT") { 3030 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RACK_ENV") { "production" }
+
+# Daemonize the server into the background. Highly suggest that
+# this be combined with "pidfile" and "stdout_redirect".
+#
+# The default is "false".
+#
+daemonize ENV.fetch("DAEMONIZE") { false }
+
+# Store the pid of the server in the file at "path".
+#
+pidfile './tmp/pids/puma.pid'
+
+# Use "path" as the file to store the server info state. This is
+# used by "pumactl" to query and control the server.
+#
+state_path './tmp/pids/puma.state'
+
+# Redirect STDOUT and STDERR to files specified. The 3rd parameter
+# ("append") specifies whether the output is appended, the default is
+# "false".
+#
+# stdout_redirect '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr'
+# stdout_redirect '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr', true

--- a/templates/project/tmp/pids/.empty_directory
+++ b/templates/project/tmp/pids/.empty_directory
@@ -1,0 +1,1 @@
+.empty_directory

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -1,10 +1,16 @@
 require 'test_helper'
 require 'haml'
 
+class StreamStub < Array
+  def closed?
+    return false
+  end
+end
+
 class AppTest < Dashing::Test
   def setup
-    @connection = []
-    app.settings.connections = [@connection]
+    @connection = {out: StreamStub.new, mutex: Mutex.new, terminated: false}
+    app.settings.connections = [ @connection ]
     app.settings.auth_token = nil
     app.settings.default_dashboard = nil
     app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')
@@ -48,9 +54,8 @@ class AppTest < Dashing::Test
   def test_post_widgets_without_auth_token
     post '/widgets/some_widget', JSON.generate({value: 6})
     assert_equal 204, last_response.status
-
-    assert_equal 1, @connection.length
-    data = parse_data @connection[0]
+    assert_equal 1, @connection[:out].length
+    data = parse_data @connection[:out][0]
     assert_equal 6, data['value']
     assert_equal 'some_widget', data['id']
     assert data['updatedAt']
@@ -72,19 +77,15 @@ class AppTest < Dashing::Test
     post '/widgets/some_widget', JSON.generate({value: 8})
     assert_equal 204, last_response.status
 
-    get '/events'
-    assert_equal 200, last_response.status
-    assert_equal 8, parse_data(@connection[0])['value']
+    assert_equal 8, parse_data(@connection[:out][0])['value']
   end
 
   def test_dashboard_events
     post '/dashboards/my_super_sweet_dashboard', JSON.generate({event: 'reload'})
     assert_equal 204, last_response.status
 
-    get '/events'
-    assert_equal 200, last_response.status
-    assert_equal 'dashboards', parse_event(@connection[0])
-    assert_equal 'reload', parse_data(@connection[0])['event']
+    assert_equal 'dashboards', parse_event(@connection[:out][0])
+    assert_equal 'reload', parse_data(@connection[:out][0])['event']
   end
 
   def test_get_dashboard

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -101,14 +101,24 @@ class CLITest < Dashing::Test
     assert_includes output, 'Could not find gist at '
   end
 
-  def test_start_task_starts_thin_with_default_port
-    command = 'bundle exec thin -R config.ru start -p 3030 '
+  def test_start_task_starts_puma_with_default_port
+    command = 'bundle exec puma '
     @cli.stubs(:run_command).with(command).once
     @cli.start
   end
 
-  def test_start_task_starts_thin_with_specified_port
-    command = 'bundle exec thin -R config.ru start -p 2020'
+  def test_start_task_starts_puma_in_daemon_mode
+      commands =  [
+          'export DAEMONIZE=true; ',
+          'bundle exec puma -d'
+      ]
+
+      @cli.stubs(:run_command).with(commands.join('')).once
+      @cli.start('-d')
+  end
+
+  def test_start_task_starts_puma_with_specified_port
+    command = 'bundle exec puma -p 2020'
     @cli.stubs(:run_command).with(command).once
     @cli.start('-p', '2020')
   end
@@ -116,7 +126,7 @@ class CLITest < Dashing::Test
   def test_start_task_supports_job_path_option
     commands = [
       'export JOB_PATH=other_spot; ',
-      'bundle exec thin -R config.ru start -p 3030 '
+      'bundle exec puma '
     ]
 
     @cli.stubs(:options).returns(job_path: 'other_spot')
@@ -124,8 +134,8 @@ class CLITest < Dashing::Test
     @cli.start
   end
 
-  def test_stop_task_stops_thin_server
-    @cli.stubs(:run_command).with('bundle exec thin stop')
+  def test_stop_task_stops_puma_server
+    @cli.stubs(:run_command).with('bundle exec pumactl --pidfile ./tmp/pids/puma.pid stop')
     @cli.stop
   end
 


### PR DESCRIPTION
- Switch server to puma, provide puma config and adapt command line
- configure puma using config/puma.rb config file
- add default puma.rb config file for new projects
- adapt dashing cli to use the config file and correctly handle -d (daemonize) arg.
- adapt cli_test.rb to the new setup
- remove tmp dir from gitignore as we want to generate it in the project template
- add tmp/pids/ dir in project template (for saving puma pid / state files.
- Properly fix SSE connections in Puma!
    - Realized that Rufus can also be multi-threaded now
    - Added a mutex for each connection, allowing safe access during send_event
    - Don't need to track a queue of events per connection - should lower memory footprint
    - Connection termination detected by catching Puma::ConnectionError exceptions during send_event conntion writing
    - Updated tests accordingly
- Modify SSE connection handling for Puma
    - Keep track of events on per-client basis
    - Clients get a UUID
    - If a client's event queue grows too big it gets dropped
    - If a Puma thread tries to send the next batch of events to a client and it's event queue is dropped, the queue will be created
    - Updated tests to match above changes