### PR TITLE
:art: silence rake warnings about unused vars

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -153,7 +153,7 @@ def format_event(body, name=nil)
 end
 
 def latest_events
-  settings.history.inject("") do |str, (id, body)|
+  settings.history.inject("") do |str, (_id, body)|
     str << body
   end
 end

--- a/lib/dashing/cli.rb
+++ b/lib/dashing/cli.rb
@@ -34,7 +34,7 @@ module Dashing
     desc "generate (widget/dashboard/job) NAME", "Creates a new widget, dashboard, or job."
     def generate(type, name)
       public_send("generate_#{type}".to_sym, name)
-    rescue NoMethodError => e
+    rescue NoMethodError => _e
       puts "Invalid generator. Either use widget, dashboard, or job"
     end
 
@@ -50,7 +50,7 @@ module Dashing
       print set_color("and run ", :yellow)
       print set_color("bundle install ", :yellow, :bold)
       say set_color("if needed. More information for this widget can be found at #{public_url}", :yellow)
-    rescue OpenURI::HTTPError => http_error
+    rescue OpenURI::HTTPError => _http_error
       say set_color("Could not find gist at #{public_url}"), :red
     end
 
@@ -88,7 +88,7 @@ module Dashing
     def run_command(command)
       begin
         system(command)
-      rescue Interrupt => e
+      rescue Interrupt => _e
         say "Exiting..."
       end
     end


### PR DESCRIPTION
Silence rake warnings by prefixing unused vars with `_`.

    smashing-1.1.0/lib/dashing/cli.rb:37: warning: assigned but unused variable - e
    smashing-1.1.0/lib/dashing/cli.rb:53: warning: assigned but unused variable - http_error
    smashing-1.1.0/lib/dashing/cli.rb:91: warning: assigned but unused variable - e
    smashing-1.1.0/lib/dashing/app.rb:156: warning: assigned but unused variable - id