### PR TITLE
removing deprecation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,5 @@ $ smashing start
 
 [Check out our wiki](https://github.com/Smashing/smashing/wiki).
 
-Note: This is a fork of the Dashing project, which is no longer being maintained. Read about that [here](https://github.com/Shopify/dashing/issues/711).
-
 ## License
 Distributed under the [MIT license](MIT-LICENSE).


### PR DESCRIPTION
Dashing isn't being maintained but Smashing is :+1: