### PR TITLE
Update README.md to include build-essential step

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Feel free to submit issues for bugs, new features, and enhancements in [GitHub](
 ## Installation
 
 ```bash
+# Install build-essential
+$ sudo apt-get install build-essential
 # Install bundler
 $ gem install bundler
 # Install smashing


### PR DESCRIPTION
Ran into a the same problem as the closed issue linked below where I didn't have `build-essential` installed on a `18.04` physical host and was unable to proceed.

https://github.com/Smashing/smashing/issues/28

Figured I'd at least provide a PR to update the `README.md` so others might skip this hurdle in case they're trying on a "clean" install that doesn't have `build-essential`.