### PR TITLE
Fixing favicon location

### DIFF
--- a/templates/project/dashboards/layout.erb
+++ b/templates/project/dashboards/layout.erb
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/assets/application.css">
 
   <link href='//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
-  <link rel="icon" href="/public/favicon.ico">
+  <link rel="icon" href="/favicon.ico">
 
 </head>
   <body>


### PR DESCRIPTION
assets within the public directory are mounted at `/` not `/public/`