### PR TITLE
:bug: Use {} as fallback for history.yaml.

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -44,7 +44,7 @@ set :auth_token, nil
 set :template_languages, %i[html erb]
 
 if File.exist?(settings.history_file)
-  set :history, YAML.load_file(settings.history_file)
+  set :history, YAML.load_file(settings.history_file, fallback: {})
 else
   set :history, {}
 end


### PR DESCRIPTION
Otherwise, YAML.load_file returns false for an empty file,
which messed the whole thing up.