### PR TITLE
Checking for existing displayedValue

### DIFF
--- a/templates/project/widgets/graph/graph.coffee
+++ b/templates/project/widgets/graph/graph.coffee
@@ -1,7 +1,7 @@
 class Dashing.Graph extends Dashing.Widget
 
   @accessor 'current', ->
-    return @get('displayedValue') if @get('displayedValue')
+    return @get('displayedValue') if @get('displayedValue')?
     points = @get('points')
     if points
       points[points.length - 1].y


### PR DESCRIPTION
I found this while trying to set the displayed value to zero. This will cause `if @get('displayedValue')` to evaluate to false. With adding a questionmark it will evaluate to true unless displayedValue is null or undefined.

Check if displayed value exist rather then if number evaluates to true. Enables the user to set the displayed value to zero.