### PR TITLE
Prevent widgets overlapping by setting overflow hidden on the list item element

### DIFF
--- a/templates/project/assets/stylesheets/application.scss
+++ b/templates/project/assets/stylesheets/application.scss
@@ -137,6 +137,13 @@ h3 {
   list-style: none;
 }
 
+// https://github.com/Shopify/dashing/issues/110
+// Prevent widgets growing outside of their designated size
+.gridster li {
+  overflow: hidden;
+  display:  list-item;
+}
+
 .gs_w {
   width: 100%;
   display: table;


### PR DESCRIPTION
fixes https://github.com/Smashing/smashing/issues/119

I do not have enough experience with css and smashing to have high confidence that this won't have negative effects elsewhere, but I can confirm that it fixes this particular issue for me.