### PR TITLE
Fix GitHub security alert updating to rake 12.3.3 (tested locally)

### DIFF
--- a/smashing.gemspec
+++ b/smashing.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('sprockets', '~> 3.7.1')
   s.add_dependency('rack', '~> 2.0.0')
 
-  s.add_development_dependency('rake', '~> 12.0.0')
+  s.add_development_dependency('rake', '~> 12.3.3')
   s.add_development_dependency('haml', '~> 5.0.1')
   s.add_development_dependency('rack-test', '~> 0.6.3')
   s.add_development_dependency('minitest', '~> 5.10.2')


### PR DESCRIPTION
Tested with ` bundle install` & `sudo gem install /home/kinow/Development/ruby/workspace/smashing/pkg/smashing-1.0.0.gem`, then `smashing new` & `smashing start`. Not sure if that's enough to confirm it's using the new version of `rake`.