### PR TITLE
Fix bug causing AnimatedValue to freeze after same value is entered

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -96,7 +96,7 @@ Dashing.AnimatedValue =
     else
       timer = "interval_#{k}"
       num = if (!isNaN(@[k]) && @[k]?) then @[k] else 0
-      unless @[timer] || num == to
+      unless @[timer] || `num == to`
         to = parseFloat(to)
         num = parseFloat(num)
         up = to > num


### PR DESCRIPTION
There appears to be a bug in `Dashing.AnimatedValue` which causes the
AnimatedValue to freeze if the new value is equal to the current. The
source of the bug seems to be due to the comparison in `num == to`
being between a float and a string. By default, CoffeeScript compiles
`==` to Javascript's `===`. Instead, if we use backticks, we can use a
"raw Javascript" command which allows us to call `==`.