### PR TITLE
Send only data that is needed on the dashboard

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -54,7 +54,7 @@ end
   settings.sprockets.append_path("assets/#{path}")
 end
 
-['widgets', File.expand_path('../../../javascripts', __FILE__)]. each do |path|
+['widgets', File.expand_path('../../../javascripts', __FILE__)].each do |path|
   settings.sprockets.append_path(path)
 end
 
@@ -141,7 +141,7 @@ end
 
 def send_event(id, body, target=nil)
   body[:id] = id
-  body[:updatedAt] ||= (Time.now.to_f * 1000.0).to_i 
+  body[:updatedAt] ||= (Time.now.to_f * 1000.0).to_i
   event = format_event(body.to_json, target)
   Sinatra::Application.settings.history[id] = event unless target == 'dashboards'
   Sinatra::Application.settings.connections.each { |out|

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -134,7 +134,7 @@ end
 
 Thin::Server.class_eval do
   def stop_with_connection_closing
-    Sinatra::Application.settings.connections.dup.each(&:close)
+    Sinatra::Application.settings.connections.dup.each_key(&:close)
     stop_without_connection_closing
   end
 

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -149,7 +149,7 @@ def send_event(id, body, target=nil)
   Sinatra::Application.settings.history[id] = event unless target == 'dashboards'
   Sinatra::Application.settings.connections.each { |out, ids|
     begin
-      out << event if ids.include?(id)
+      out << event if target == 'dashboards' || ids.include?(id)
     rescue IOError => e # if the socket is closed an IOError is thrown
       Sinatra::Application.settings.connections.delete(out)
     end

--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -80,7 +80,9 @@ get '/events', :provides => 'text/event-stream' do
   ids = params[:ids].to_s.split(',').to_set
   stream :keep_open do |out|
     settings.connections[out] = ids
-    out << latest_events(ids)
+    settings.history.each do |id, event|
+      out << event if ids.include?(id)
+    end
     out.callback { settings.connections.delete(out) }
   end
 end
@@ -158,12 +160,6 @@ def format_event(body, name=nil)
   str = ""
   str << "event: #{name}\n" if name
   str << "data: #{body}\n\n"
-end
-
-def latest_events(ids)
-  settings.history.each_with_object("") do |(id, body), str|
-    str << body if ids.include?(id)
-  end
 end
 
 def first_dashboard

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -4,7 +4,9 @@ require 'haml'
 class AppTest < Dashing::Test
   def setup
     @connection = []
-    app.settings.connections = [@connection]
+    # stop sinatra from handling Hash value specially which makes it merge new value into previous one
+    app.settings.connections = nil
+    app.settings.connections = {@connection => ['some_widget']}
     app.settings.auth_token = nil
     app.settings.default_dashboard = nil
     app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')


### PR DESCRIPTION
Get list of data ids after all widgets are created and send it as parameter to event stream endpoint so it sends only requested data.
This is especially useful when one app has multiple dashboards which consume different data.