### PR TITLE
Relax dependencies 🔧  🍎 

### DIFF
--- a/smashing.gemspec
+++ b/smashing.gemspec
@@ -26,25 +26,25 @@ Gem::Specification.new do |s|
 
   s.files = Dir['README.md', 'javascripts/**/*', 'templates/**/*','templates/**/.[a-z]*', 'lib/**/*']
 
-  s.add_dependency('coffee-script', '~> 2.4.1')
-  s.add_dependency('execjs', '~> 2.7.0')
+  s.add_dependency('coffee-script', '~> 2.4')
+  s.add_dependency('execjs', '~> 2.7')
   if RUBY_VERSION < "2.4.0"
     s.add_dependency('sinatra', '= 2.0.4') 
   else
-    s.add_dependency('sinatra', '~> 2.0.0')
+    s.add_dependency('sinatra', '~> 2.0')
   end
-  s.add_dependency('sinatra-contrib', '~> 2.0.0')
-  s.add_dependency('thin', '~> 1.7.2')
-  s.add_dependency('rufus-scheduler', '~> 3.6.0')
-  s.add_dependency('thor', '~> 1.0.1')
+  s.add_dependency('sinatra-contrib', '~> 2.0')
+  s.add_dependency('thin', '~> 1.7')
+  s.add_dependency('rufus-scheduler', '~> 3.6')
+  s.add_dependency('thor', '~> 1.0')
   if RUBY_VERSION < "2.5.0"
-    s.add_dependency('sprockets', '~> 3.7.1')
-    s.add_dependency('sass', '~> 3.4.24')
+    s.add_dependency('sprockets', '~> 3.7')
+    s.add_dependency('sass', '~> 3.4')
   else
     s.add_dependency('sprockets', '~> 4.0')
     s.add_dependency('sassc', '~> 2.0')
   end
-  s.add_dependency('rack', '~> 2.2.2')
+  s.add_dependency('rack', '~> 2.2')
 
   s.add_development_dependency('rake', '~> 12.3.3')
   s.add_development_dependency('haml', '~> 5.0.1')


### PR DESCRIPTION
This PR relaxes many of the dependencies that smashing has. This should allow users to upgrade dependant gems without requiring a release of smashing. A good example of where this is require is in #174

In #174 we need to upgrade to `thin` `>= 1.8.0` in order to be able to [compile it against XCode 12](https://github.com/macournoyer/thin/issues/372) however since Smashing was dependant on version `~> 1.7.2` that means we could only use releases that were `>= 1.7.2` and `< 1.8.0` i.e. we can't use the new version.

This relaxes many dependencies to allow users to upgrade to new feature releases, but not to the next X (breaking) release. Given that breaking changes should require a major release as per [semver](https://semver.org/) we should expect that this wouldn't cause any issues.

I did have a look through the commit messages to see if there was any specific reason why the dependencies were so strict and couldn't find any. If there are good reasons though please let me know.