### PR TITLE
Create EventSource at the right moment

### DIFF
--- a/javascripts/dashing.coffee
+++ b/javascripts/dashing.coffee
@@ -123,7 +123,7 @@ Dashing.lastEvents = lastEvents = {}
 Dashing.debugMode = false
 
 Dashing.on 'run', ->
-  setTimeout -> # run only when all widgets are created
+  @layout.on 'ready', -> # run only when all widgets are created
     ids = Object.keys(Dashing.widgets)
     source = new EventSource('events?ids=' + encodeURIComponent(ids.join(',')))
     source.addEventListener 'open', (e) ->
@@ -153,7 +153,6 @@ Dashing.on 'run', ->
         console.log("Received data for dashboards", data)
       if data.dashboard is '*' or window.location.pathname is "/#{data.dashboard}"
         Dashing.fire data.event, data
-  , 0
 
 $(document).ready ->
   Dashing.run()


### PR DESCRIPTION
Closes #180

On small dashboard setTimeout with timeout 0 was enough to create
EventSource after all widgets were initialised, but on big dashboards
the ready event of layout (View instance for document) is the only event
that is happening after all widgets get initialised and registered in
the list.