### PR TITLE
:bug: Fix dashing install

### DIFF
--- a/lib/dashing/downloader.rb
+++ b/lib/dashing/downloader.rb
@@ -11,7 +11,7 @@ module Dashing
     end
 
     def get_json(url)
-      response = open(url).read
+      response = URI.open(url).read
       JSON.parse(response)
     end
   end


### PR DESCRIPTION
Replaced open with URI.open, as Kernel#open was deprecated in Ruby 2.7 and doens't work anymore with Ruby 3

Details: https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a